### PR TITLE
Fixed Firebase config and used better react-sketch library

### DIFF
--- a/my-app/package-lock.json
+++ b/my-app/package-lock.json
@@ -13334,10 +13334,10 @@
         "workbox-webpack-plugin": "5.1.4"
       }
     },
-    "react-sketch": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/react-sketch/-/react-sketch-0.5.1.tgz",
-      "integrity": "sha512-a0BPc6z/Ec/7KN4KL/HGLfAhDfLyaBN8GDvILfBZVX74PnhWvJocofc/cHSCvtNtEmGSdmJPjrewfAUXKo78pA==",
+    "react-sketch2": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/react-sketch2/-/react-sketch2-0.5.7.tgz",
+      "integrity": "sha512-HisVkQ/EE0dg22H9iqvkoxINVAmCwvnMiJ3HEVD80u97MFm/v/6PuTJf+BMJ8tA1bH6RtTLaWmupkC8lHFg1gw==",
       "requires": {
         "prop-types": "^15.6.2",
         "react": "^16.6.1",

--- a/my-app/package.json
+++ b/my-app/package.json
@@ -14,7 +14,7 @@
     "react-dom": "^17.0.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",
-    "react-sketch": "^0.5.1",
+    "react-sketch2": "^0.5.7",
     "typescript": "^4.2.3"
   },
   "scripts": {

--- a/my-app/src/components/Whiteboard.js
+++ b/my-app/src/components/Whiteboard.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import {SketchField, Tools} from 'react-sketch'
+import {SketchField, Tools} from 'react-sketch2'
 interface propType
 {
 }

--- a/my-app/src/firebaseInit.tsx
+++ b/my-app/src/firebaseInit.tsx
@@ -3,16 +3,18 @@ import "firebase/auth"
 import "firebase/analytics"
 import "firebase/database"
 // Configure Firebase
-// Pretty sure this is ill-advised but I don't really know where else to put these right now
+// TODO: FIXME: This config should be stored in an env file once the mvp
+// is complete. Otherwise this is a security concern and will lead to the abuse
+// of API keys
 export const firebaseConfig = {
   apiKey: "AIzaSyBLfvlNwNehgXM2jCzx75wADA5xRssDChs",
   authDomain: "live-web-tutor.firebaseapp.com",
+  databaseURL: "https://live-web-tutor-default-rtdb.firebaseio.com",
   projectId: "live-web-tutor",
   storageBucket: "live-web-tutor.appspot.com",
   messagingSenderId: "332165633586",
-  databaseURL: "live-web-tutor-default-rtdb.firebaseio.com",
-  appId: "1:1082477495907:web:a85d8ff36c2163a7abda56",
-  measurementId: "G-KG3Y18ELCQ",
+  appId: "1:332165633586:web:25de3e35ffe8cff5ee0e2b",
+  measurementId: "G-0Q6B99NS1Z",
 }
 
 // Firebase app was getting initialized twice before, no idea why, just added this to fix it. Should get rid of this later


### PR DESCRIPTION
**Description**

Alright, so right now the production website is blank, even though everything works in dev. I dug around for an hour and realized that the reason this was happening was because the production version of the project actually crashed and had errors, hence the white screen. If you open up the console you can see any errors on production.

I ended up doing a bunch of stuff but in the end it came down to the fact that the `react-sketch` library was outdated and contained many bugs. See [here](https://github.com/tbolis/react-sketch/issues/129) and [here](https://github.com/tbolis/react-sketch/issues/126) for the two major issues I found with the library. The latter issue prevented it from working on Firefox specifically and the former issue prevented it from working on production.

The band-aid solution is to use a fork of `react-sketch` that's published on npm as 'react-sketch2'. [See here for the forked project](https://github.com/x5engine/react-sketch), which allows it to successfully build and run on my local machine. It turns out the original library built properly on my machine, but didn't run. **Note that every version runs on the dev build, so you wouldn't notice any errors that way which was why production never matched what was on everyone's machines.**

There also was in issue with our Firebase config (we didn't have an `appId` because you need to create an "app" on Firebase. I did that in the console and updated the config. Hopefully this one works!